### PR TITLE
Add alternative input sample rate support

### DIFF
--- a/DLL/Mods/AlternativeSampleRateMod.cpp
+++ b/DLL/Mods/AlternativeSampleRateMod.cpp
@@ -21,6 +21,12 @@ void AlternativeSampleRateMod::OnInitialize(ModContext& c) {
 
 	AudioDevices::output_SampleRate = sampleRate;
 	AudioDevices::ChangeOutputSampleRate();
+
+	// Input follows output - RS-ASIO requires the engine's input and output rate to both match the
+	// interface's single native rate, so there's no legitimate case where a user would want them to
+	// differ. No separate input toggle/value is exposed.
+	AudioDevices::input_SampleRate = sampleRate;
+	AudioDevices::ChangeInputSampleRate();
 }
 
 // Patch the markers only during the loading phase, before the engine finishes coming up. The buffer

--- a/DLL/Mods/AlternativeSampleRateMod.hpp
+++ b/DLL/Mods/AlternativeSampleRateMod.hpp
@@ -4,7 +4,8 @@
 #include "../Framework/Framework.hpp"
 
 // Forces the audio engine's sample-rate buffer markers during boot when the user runs an alternative
-// output sample rate. Loading-phase only (the engine only reads them while coming up) and apply-only.
+// output sample rate, and patches the analogous input/capture constants to match. Loading-phase only
+// (the engine only reads them while coming up) and apply-only.
 class AlternativeSampleRateMod : public Framework::IMod {
 public:
 	MOD_ID(AlternativeSampleRateMod)

--- a/DLL/Mods/AudioDevices.cpp
+++ b/DLL/Mods/AudioDevices.cpp
@@ -299,3 +299,27 @@ void AudioDevices::ChangeOutputSampleRate() {
 	MemUtil::PlaceHook(Offsets::ptr_sampleRateRequirementAudioOutput, hook_changeSampleRate, 5);
 	MemUtil::PlaceHook(Offsets::ptr_sampleRateDivZeroCrash, hook_sampleRate_FixDivZeroCrash, 5);
 }
+
+/// <summary>
+/// Reads the sample rate from input_SampleRate and writes it over the six hardcoded 48000
+/// constants the audio input/capture path checks against, plus the matching double-precision
+/// constant. Unlike output, there's no single call site to hook with a dynamic register write -
+/// these are static constants baked into the code/data, so this patches them directly and must
+/// run on boot, before the audio engine reads them. Has no effect when run afterwards.
+/// </summary>
+void AudioDevices::ChangeInputSampleRate() {
+	if (Offsets::ptr_sampleRateRequirementAudioInputSites.empty() ||
+		Offsets::ptr_sampleRateRequirementAudioInputSites[0].GetValue() == 0) {
+		LOG_WARNING("[!] Alternative input sample rate requested, but the input sample rate offsets are not known for this game build. Skipping." << std::endl);
+		return;
+	}
+
+	for (VersioningStruct<uintptr_t>& site : Offsets::ptr_sampleRateRequirementAudioInputSites) {
+		MemUtil::PatchAdr(site, &AudioDevices::input_SampleRate, 4);
+	}
+
+	if (Offsets::ptr_sampleRateRequirementAudioInputDouble.GetValue() != 0) {
+		double inputSampleRateDouble = (double)AudioDevices::input_SampleRate;
+		MemUtil::PatchAdr(Offsets::ptr_sampleRateRequirementAudioInputDouble, &inputSampleRateDouble, 8);
+	}
+}

--- a/DLL/Mods/AudioDevices.hpp
+++ b/DLL/Mods/AudioDevices.hpp
@@ -5,8 +5,10 @@ namespace AudioDevices {
 	void SetMicrophoneVolume(std::string microphoneName, int volume);
 	int GetMicrophoneVolume(std::string microphoneName);
 	void ChangeOutputSampleRate();
+	void ChangeInputSampleRate();
 
 	inline std::map<std::string, LPWSTR> activeMicrophones;
 
 	inline int output_SampleRate = 48000;
+	inline int input_SampleRate = 48000;
 };

--- a/DLL/Offsets.cpp
+++ b/DLL/Offsets.cpp
@@ -86,6 +86,10 @@ void Offsets::Initialize() {
 	ptr_sampleRateSize = { {0x135198C, baseHandle + 0x00F5298C } };								// Static Memory | 00 40 1c 46 02 00 00 00 00 00 00 00 (second variable)
 	ptr_sampleRateBuffer = { {0x1251A9C, baseHandle + 0x00E52A9C } };							// Static Memory | 80 bb 00 00 80 00 00 00 (second variable)
 
+	// Sample rate mod (input / RTC / mic capture device open path)
+	// RVAs from L0FKA's RS_ASIO fork build ebf44968-dirty (2026-08-20); only verified for RemasteredSeptember2022.
+	ptr_sampleRateRequirementAudioInputDouble = { {0x01224A40, 0} };		// Static Memory | 00 00 00 00 00 70 e7 40 (double 48000.0)
+
 	ptr_stringColor = { {0x135F58C, baseHandle + 0x00F6058C } };								// Static Memory | 56 e8 ? ? ? ? 83 c4 04 89 46 14 (look at variable set at end of function)
 	ptr_drunkShit = { {0x12F7C20, baseHandle + 0x00EF8C20 } };									// Static Memory | ab aa aa 3e (first variable)
 
@@ -214,6 +218,18 @@ namespace Offsets { // Addresses for pre-2021 patch are in the comments
 
 	std::vector<unsigned int> ptr_noteDataOffsets{ 0xB0, 0x18, 0x4, 0x84, 0x0 };
 	std::vector<unsigned int> ptr_scoreAttackNoteDataOffsets{ 0xB0, 0x18, 0x4, 0x4C, 0x0 };
+
+	// Sample rate mod (input / RTC / mic capture device open path) - six separate constants,
+	// unlike output's single site. RVAs from L0FKA's RS_ASIO fork build ebf44968-dirty
+	// (2026-08-20); only verified for RemasteredSeptember2022, LPDecember2024 unknown (left 0).
+	std::vector<VersioningStruct<uintptr_t>> ptr_sampleRateRequirementAudioInputSites{
+		VersioningStruct<uintptr_t>({ 0x00C45D3C, 0 }),
+		VersioningStruct<uintptr_t>({ 0x00C4607C, 0 }),
+		VersioningStruct<uintptr_t>({ 0x00C46221, 0 }),
+		VersioningStruct<uintptr_t>({ 0x00C465BE, 0 }),
+		VersioningStruct<uintptr_t>({ 0x00C46838, 0 }),
+		VersioningStruct<uintptr_t>({ 0x00C47069, 0 }),
+	};
 }
 
 

--- a/DLL/Offsets.hpp
+++ b/DLL/Offsets.hpp
@@ -192,6 +192,15 @@ namespace Offsets {
 	inline VersioningStruct<uintptr_t> ptr_sampleRateSize;
 	inline VersioningStruct<uintptr_t> ptr_sampleRateBuffer;
 
+	// Adjust sample rate requirements (audio input / RTC / mic capture device open path)
+	// RVAs sourced from L0FKA's RS_ASIO fork (build ebf44968-dirty, 2026-08-20), which patches
+	// these same constants when its own GameSampleRate ini setting is enabled - confirmed live via
+	// that fork's RS_ASIO-log.txt against the currently-installed game build. Only verified for
+	// RemasteredSeptember2022; LPDecember2024 equivalents are unknown and left 0, so
+	// AudioDevices::ChangeInputSampleRate() no-ops on that build until they're found.
+	extern std::vector<VersioningStruct<uintptr_t>> ptr_sampleRateRequirementAudioInputSites;
+	inline VersioningStruct<uintptr_t> ptr_sampleRateRequirementAudioInputDouble;
+
 	// Misc Mods
 	inline VersioningStruct<uintptr_t> ptr_stringColor;
 	inline VersioningStruct<uintptr_t> ptr_drunkShit; //search for float 0.333333, seems like it's static

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Same VKey format. Require `VolumeControl = on`. Use Control with the key to decr
 | `AllowAudioInBackground` | `off` | on/off | Keep audio when alt-tabbed. |
 | `BypassTwoRTCMessageBox` | `off` | on/off | Allow two RTCs in singleplayer without popup. |
 | `LinearRiffRepeater` | `off` | on/off | Linear RR speed (68% UI = 68% real). |
-| `AltOutputSampleRate` | `off` | on/off | Use non-48 kHz output sample rate. |
+| `AltOutputSampleRate` | `off` | on/off | Use non-48 kHz sample rate for output *and* input (RTC/mic capture) - both follow the same value, since your interface only has one native rate. |
 | `AllowLooping` | `off` | on/off | Custom loop markers (LoopStart/End keys). |
 | `AllowRewind` | `off` | on/off | Rewind key. |
 | `FixOculusCrash` | `off` | on/off | Mitigate crash with Oculus/Meta headsets. |
@@ -290,7 +290,7 @@ Numeric values used by the DLL (`customSettings`). Times are **milliseconds** un
 | `SecondaryMonitorYPosition` | `0` | int | Virtual desktop Y of secondary monitor top-left. |
 | `SeparateNoteColorsMode` | `0` | `0` / `1` / `2` | `0` = same as strings, `1` = stock note colors, `2` = custom note colors. |
 | `OverrideInputVolume` | `17` | `0`–`100` | Input volume override (Rocksmith’s stock “default” is 17). |
-| `AlternativeOutputSampleRate` | `48000` | e.g. `44100`, `48000` | Used when `AltOutputSampleRate = on`. |
+| `AlternativeOutputSampleRate` | `48000` | e.g. `44100`, `48000` | Used when `AltOutputSampleRate = on`. Applies to both output and input. |
 | `LoopingLeadUp` | `0` | ms | Lead-in before custom loops. |
 | `RewindBy` | `5000` | ms | How far rewind jumps. |
 | `RewindLeadup` | `2000` | ms | Grey note / lead-up adjust after rewind. |


### PR DESCRIPTION
Adds support for running Rocksmith's audio **input** (guitar/RTC/mic capture) at an alternative sample rate, mirroring the existing `AltOutputSampleRate` feature for output.

## Why
Audio interfaces that don't support 48kHz (e.g. HOTONE AUDIO USB, native 44.1kHz only) could already have their *output* patched via `AltOutputSampleRate`, but input had no equivalent — see #236. Input always requested 48000 regardless of the output setting, so interfaces without 48kHz support couldn't record at all.

## What changed
- Patches the six hardcoded 48000 constants on the audio input/capture path, plus a matching double-precision constant (`DLL/Offsets.hpp`/`.cpp`, `DLL/Mods/AudioDevices.cpp`/`.hpp`)
- Input sample rate now follows output automatically in `AlternativeSampleRateMod.cpp` — no separate toggle, since RS-ASIO requires both directions to match the interface's single native rate
- Only verified for the `RemasteredSeptember2022` build; `LPDecember2024` offsets are unknown and left unset (no-ops with a warning)

## How it was found / verified
Cross-referenced against [L0FKA's RS_ASIO fork](https://github.com/Lovrom8/RSMods/issues/236#issuecomment-5230459598), which patches the same constants when its `GameSampleRate` ini option is enabled. Confirmed the exact RVAs live via that fork's `RS_ASIO-log.txt`, then re-verified this patch working standalone (fork reverted to stock RS_ASIO, tested against a fresh official v1.2.8.4 install) with `RS_ASIO-log.txt` showing `{ASIO IN 0}` initializing cleanly at 44100 Hz and streaming real capture buffers.

Closes #236