### PR TITLE
Fix Wine / Proton compatibility

### DIFF
--- a/DLL/MemUtil.cpp
+++ b/DLL/MemUtil.cpp
@@ -256,13 +256,49 @@ uintptr_t MemUtil::ReadPtr(uintptr_t adr) {
 	return *(uintptr_t*)adr;
 }
 
+/// <summary>
+/// Are we running under Wine / Proton rather than on Windows?
+/// </summary>
+/// <returns>True if the host is Wine.</returns>
+bool MemUtil::IsRunningOnWine()
+{
+	static bool checked = false;
+	static bool isWine = false;
+
+	if (!checked) {
+		HMODULE hNtdll = GetModuleHandleA("ntdll.dll");
+		if (hNtdll && GetProcAddress(hNtdll, "wine_get_version") != nullptr) {
+			isWine = true;
+		}
+		checked = true;
+	}
+
+	return isWine;
+}
+
 NTSTATUS MemUtil::HookedVirtualProtect(LPVOID address, SIZE_T len, ULONG newProtection, ULONG& oldProtection)
 {
+	if (IsRunningOnWine()) {
+		DWORD oldProtect = 0;
+		if (VirtualProtect(address, len, newProtection, &oldProtect)) {
+			oldProtection = oldProtect;
+			return 0; // STATUS_SUCCESS
+		}
+		return 0xC0000001; // STATUS_UNSUCCESSFUL
+	}
+
 	return NtProtectVirtualMemory(GetCurrentProcess(), &address, &len, newProtection, &oldProtection);
 }
 
 NTSTATUS MemUtil::HookedQueryVirtualMemory(LPVOID address, PMEMORY_BASIC_INFORMATION memoryBuffer, SIZE_T dwLength)
 {
+	if (IsRunningOnWine()) {
+		if (VirtualQuery(address, memoryBuffer, dwLength) != 0) {
+			return 0; // STATUS_SUCCESS
+		}
+		return 0xC0000001; // STATUS_UNSUCCESSFUL
+	}
+
 	SIZE_T returnLength = 0;
 	return NtQueryVirtualMemory(GetCurrentProcess(), address, MemoryBasicInformation, memoryBuffer, dwLength, &returnLength);
 }

--- a/DLL/MemUtil.hpp
+++ b/DLL/MemUtil.hpp
@@ -28,6 +28,7 @@ namespace MemUtil {
 		requires std::is_trivially_copyable_v<T>
 	T ReadValue(uintptr_t adr, bool addBaseHandle);
 
+	bool IsRunningOnWine();
 	NTSTATUS HookedVirtualProtect(LPVOID address, SIZE_T len, ULONG newProtection, ULONG& oldProtection);
 	NTSTATUS HookedQueryVirtualMemory(LPVOID address, PMEMORY_BASIC_INFORMATION memoryBuffer, SIZE_T dwLength);
 

--- a/DLL/ModManager.cpp
+++ b/DLL/ModManager.cpp
@@ -4,6 +4,91 @@
 
 namespace Setting = Settings::Setting;
 
+namespace {
+	typedef IDirect3D9* (WINAPI* tDirect3DCreate9)(UINT SDKVersion);
+
+	/// <summary>
+	/// Read the IDirect3DDevice9 vTable out of a throwaway device.
+	/// Every device handed out by a given d3d9.dll shares one vTable, so the entries we find here are
+	/// the ones the game's real device calls through. Works the same on Microsoft's d3d9, WineD3D, and DXVK.
+	/// </summary>
+	/// <param name="d3d9Module"> - Handle of the d3d9.dll the game loaded.</param>
+	/// <returns>The device vTable, or NULL if we couldn't create a device to read it from.</returns>
+	void** GetD3D9DeviceVTable(HMODULE d3d9Module) {
+		// Resolve the entry point out of the module the game already loaded, rather than importing it.
+		// That keeps us from pulling d3d9.dll into the process earlier than the game would itself.
+		tDirect3DCreate9 direct3DCreate9 = (tDirect3DCreate9)GetProcAddress(d3d9Module, "Direct3DCreate9");
+
+		if (!direct3DCreate9) {
+			LOG_ERROR("d3d9.dll does not export Direct3DCreate9." << std::endl);
+			return NULL;
+		}
+
+		IDirect3D9* d3d9 = direct3DCreate9(D3D_SDK_VERSION);
+
+		if (!d3d9) {
+			LOG_ERROR("Direct3DCreate9 failed." << std::endl);
+			return NULL;
+		}
+
+		D3DPRESENT_PARAMETERS presentParameters{};
+		presentParameters.Windowed = TRUE;
+		presentParameters.SwapEffect = D3DSWAPEFFECT_DISCARD;
+		presentParameters.hDeviceWindow = GetDesktopWindow();
+
+		IDirect3DDevice9* dummyDevice = NULL;
+		HRESULT result = d3d9->CreateDevice(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, presentParameters.hDeviceWindow, D3DCREATE_SOFTWARE_VERTEXPROCESSING, &presentParameters, &dummyDevice);
+
+		// DXVK's NULLREF support is unreliable, so it is only worth trying once HAL has already failed.
+		if (FAILED(result)) {
+			LOG_WARNING("Could not create a HAL device (0x" << std::hex << result << std::dec << "). Retrying with NULLREF." << std::endl);
+			result = d3d9->CreateDevice(D3DADAPTER_DEFAULT, D3DDEVTYPE_NULLREF, presentParameters.hDeviceWindow, D3DCREATE_SOFTWARE_VERTEXPROCESSING, &presentParameters, &dummyDevice);
+		}
+
+		void** vTable = NULL;
+
+		if (SUCCEEDED(result) && dummyDevice) {
+			vTable = *(void***)dummyDevice;
+			dummyDevice->Release();
+		}
+		else
+			LOG_ERROR("Could not create a D3D9 device to read the vTable from. Error: 0x" << std::hex << result << std::dec << std::endl);
+
+		d3d9->Release();
+
+		return vTable;
+	}
+
+	/// <summary>
+	/// Point a vTable entry at one of our hooks, handing back the entry we replaced so the hook can chain to it.
+	/// One pointer write, so it makes no assumptions about what the function it replaces looks like.
+	/// </summary>
+	/// <param name="vTable"> - Device vTable.</param>
+	/// <param name="index"> - Index of the function to hook (see D3DInfo).</param>
+	/// <param name="hook"> - Our replacement function.</param>
+	/// <param name="original"> - Receives the function we replaced.</param>
+	/// <returns>Was the hook installed?</returns>
+	template <typename TOriginal, typename THook>
+	bool HookVTableEntry(void** vTable, int index, THook hook, TOriginal& original) {
+		DWORD oldProtection;
+
+		// The vTable lives in read-only data, so it has to be made writable for the one pointer we swap.
+		NTSTATUS status = MemUtil::HookedVirtualProtect(&vTable[index], sizeof(void*), PAGE_READWRITE, oldProtection);
+		if (!NT_SUCCESS(status)) {
+			LOG_ERROR("Could not unprotect the vTable entry at index " << index << ". Status: 0x" << std::hex << status << std::dec << std::endl);
+			return false;
+		}
+
+		original = (TOriginal)vTable[index];
+		vTable[index] = (void*)hook;
+
+		DWORD backup;
+		MemUtil::HookedVirtualProtect(&vTable[index], sizeof(void*), oldProtection, backup);
+
+		return true;
+	}
+}
+
 namespace ModManager {
 	void InitializeConfiguration() {
 		if (!(std::ifstream("RSMods.ini"))) {
@@ -37,61 +122,30 @@ namespace ModManager {
 	/// Hook Game Functions For Our Own Uses (On Alt-Tab, Draw UI, etc).
 	/// </summary>
 	void GUI() {
-		uint32_t d3d9Base;
-		uint32_t adr;
-		uint32_t* vTable = NULL;
+		HMODULE d3d9Module;
 
-		// Find D3D Device
-		while ((d3d9Base = (uint32_t)GetModuleHandleA("d3d9.dll")) == NULL)
+		// Wait for the game to load its Direct3D 9 implementation.
+		while ((d3d9Module = GetModuleHandleA("d3d9.dll")) == NULL)
 			Sleep(500);
-		adr = MemUtil::FindPattern<uint32_t>(d3d9Base, Offsets::d3dDevice_SearchLen, (byte*)Offsets::d3dDevice_Pattern, Offsets::d3dDevice_Mask) + 2;
 
-		bool runningThroughWine = adr == (uint32_t)2;
+		void** vTable = GetD3D9DeviceVTable(d3d9Module);
 
-		LOG_INFO("Running in Wine: " << std::boolalpha << runningThroughWine << std::endl);
-
-		// Proton / Wine Check.
-		// We do NOT support linux. There is some issues with the D3D pointers.
-		// This check is meant so if someone does load our mods on Linux, we won't just crash. Most mods will just not work.
-		if (runningThroughWine) {
-			LOG_INFO("Performing Wine check" << std::endl);
-			adr = MemUtil::FindPattern<uint32_t>(0x2000000, 0x2B778CC, (byte*)Offsets::d3dDevice_Pattern, Offsets::d3dDevice_Mask) + 2;
-			LOG_INFO(adr << std::endl);
-		}
-
-		if (!adr) {
-			LOG_ERROR("Could not find D3D9 device pointer." << std::endl);
-			return;
-		}
-
-		if (!*(uint32_t*)adr) { // Wing it
-			LOG_ERROR("Could not find DX9 device." << std::endl);
-			MessageBoxA(NULL, "Could not find DX9 device, please restart the game!", "Error", NULL);
-			return;
-		}
-
-		vTable = *(uint32_t**)adr;
-
-		// Third time's the charm?
-		if (!vTable || vTable < (uint32_t*)Offsets::baseHandle) {
+		if (!vTable) {
 			LOG_ERROR("Could not find D3D device's vTable address." << std::endl);
 			MessageBoxA(NULL, "Could not find D3D device's vTable address \n Restart the game and if you still get this error after a few tries, please report the error!", "Error", NULL);
 			return;
 		}
 
 		// Hook D3D functions to use for our own D3D work. Reference D3DHooks
-		if (!runningThroughWine) {
-			oSetVertexDeclaration = (tSetVertexDeclaration)MemUtil::TrampHook((byte*)vTable[D3DInfo::SetVertexDeclaration_Index], (byte*)D3DHooks::Hook_SetVertexDeclaration, 7); // https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-setvertexdeclaration
-			oSetVertexShaderConstantF = (tSetVertexShaderConstantF)MemUtil::TrampHook((byte*)vTable[D3DInfo::SetVertexShaderConstantF_Index], (byte*)D3DHooks::Hook_SetVertexShaderConstantF, 7); // https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-setvertexshaderconstantf
-			oReset = (tReset)DetourFunction((byte*)vTable[D3DInfo::Reset_Index], (byte*)D3DHooks::Hook_Reset); // https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-reset
-		}
-
-		oSetVertexShader = (tSetVertexShader)MemUtil::TrampHook((byte*)vTable[D3DInfo::SetVertexShader_Index], (byte*)D3DHooks::Hook_SetVertexShader, 7); // https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-setvertexshader
-		oSetPixelShader = (tSetPixelShader)MemUtil::TrampHook((byte*)vTable[D3DInfo::SetPixelShader_Index], (byte*)D3DHooks::Hook_SetPixelShader, 7); // https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-setpixelshader
-		oSetStreamSource = (tSetStreamSource)MemUtil::TrampHook((byte*)vTable[D3DInfo::SetStreamSource_Index], (byte*)D3DHooks::Hook_SetStreamSource, 7); // https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-setstreamsource
-		oEndScene = (tEndScene)MemUtil::TrampHook((byte*)vTable[D3DInfo::EndScene_Index], (byte*)D3DHooks::Hook_EndScene, 7); // https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-endscene
-		oDrawIndexedPrimitive = (tDrawIndexedPrimitive)MemUtil::TrampHook((byte*)vTable[D3DInfo::DrawIndexedPrimitive_Index], (byte*)D3DHooks::Hook_DIP, 5); // https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-drawindexedprimitive
-		oDrawPrimitive = (tDrawPrimitive)MemUtil::TrampHook((byte*)vTable[D3DInfo::DrawPrimitive_Index], (byte*)D3DHooks::Hook_DP, 7); // https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-drawprimitive
+		HookVTableEntry(vTable, D3DInfo::SetVertexDeclaration_Index, D3DHooks::Hook_SetVertexDeclaration, oSetVertexDeclaration); // https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-setvertexdeclaration
+		HookVTableEntry(vTable, D3DInfo::SetVertexShaderConstantF_Index, D3DHooks::Hook_SetVertexShaderConstantF, oSetVertexShaderConstantF); // https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-setvertexshaderconstantf
+		HookVTableEntry(vTable, D3DInfo::Reset_Index, D3DHooks::Hook_Reset, oReset); // https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-reset
+		HookVTableEntry(vTable, D3DInfo::SetVertexShader_Index, D3DHooks::Hook_SetVertexShader, oSetVertexShader); // https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-setvertexshader
+		HookVTableEntry(vTable, D3DInfo::SetPixelShader_Index, D3DHooks::Hook_SetPixelShader, oSetPixelShader); // https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-setpixelshader
+		HookVTableEntry(vTable, D3DInfo::SetStreamSource_Index, D3DHooks::Hook_SetStreamSource, oSetStreamSource); // https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-setstreamsource
+		HookVTableEntry(vTable, D3DInfo::EndScene_Index, D3DHooks::Hook_EndScene, oEndScene); // https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-endscene
+		HookVTableEntry(vTable, D3DInfo::DrawIndexedPrimitive_Index, D3DHooks::Hook_DIP, oDrawIndexedPrimitive); // https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-drawindexedprimitive
+		HookVTableEntry(vTable, D3DInfo::DrawPrimitive_Index, D3DHooks::Hook_DP, oDrawPrimitive); // https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-drawprimitive
 	}
 
 	/// <summary>

--- a/DLL/Mods/Enumeration.cpp
+++ b/DLL/Mods/Enumeration.cpp
@@ -9,12 +9,13 @@ void SaveSteamServicePointer(uint32_t eax) {
 }
 
 uint32_t hookBackAddr;
+uint32_t pushedPrologueValue;
 
 void __declspec(naked) Hook_EnumerationService() {
 	__asm {
 		push ebp
 		mov ebp, esp
-		and esp, 0FFFFFFF8h
+		push dword ptr[pushedPrologueValue]
 
 		pushad
 
@@ -44,6 +45,8 @@ void Enumeration::HookEnumerationService() {
 	}
 
 	hookBackAddr = hookAddr + len;
+	pushedPrologueValue = (uint32_t)(int32_t)*(int8_t*)(hookAddr + 4); // The imm8 of `push imm8`, at offset 4 of the signature.
+
 	if (MemUtil::PlaceHook((void*)hookAddr, Hook_EnumerationService, len)) {
 		LOG_INFO("Hooked Steam enumeration function successfully!" << std::endl);
 	}

--- a/DLL/Offsets.cpp
+++ b/DLL/Offsets.cpp
@@ -154,11 +154,6 @@ namespace Offsets { // Addresses for pre-2021 patch are in the comments
 	const char* patch_ListNumbers = "\x5A\x5A\x90\x90\x90";
 	const char* patch_SprintfArgs = "\x04";
 
-	// D3D Stuff
-	const char* d3dDevice_Pattern = "\xC7\x06\x00\x00\x00\x00\x89\x86\x00\x00\x00\x00\x89\x86";
-	uint32_t d3dDevice_SearchLen = 0x128000;
-	const char* d3dDevice_Mask = "xx????xx????xx";
-
 	// Multiplayer
 	std::vector<unsigned int> ptr_multiplayerOffsets{ 0x24, 0x28, 0x14, 0x90, 0xC };
 

--- a/DLL/Offsets.hpp
+++ b/DLL/Offsets.hpp
@@ -73,11 +73,6 @@ namespace Offsets {
 	inline VersioningStruct<uintptr_t> xinputModule;
 	inline VersioningStruct<uintptr_t> xinputEnable;
 
-	//D3D Stuff
-	extern const char* d3dDevice_Pattern;
-	extern uint32_t d3dDevice_SearchLen;
-	extern const char* d3dDevice_Mask;
-
 	// Multiplayer
 	inline VersioningStruct<uintptr_t> ptr_multiplayer;
 	extern std::vector<unsigned int> ptr_multiplayerOffsets;

--- a/README.md
+++ b/README.md
@@ -143,7 +143,14 @@ Feel free to try the 1.2.8.0 version if you are on the Learn & Play version.
 1. Manually build/copy the DLL to the root folder of Rocksmith 2014 RM, create a file called RSMods.ini and fill it with options as [shown below](https://github.com/Lovrom8/RSMods#settings)
    If it is installed in the most common folder (C drive, Program Files/Steam/Steamapps), VS will attempt to copy the DLL to the folder for your convenience.
 2. Use the One-Click-Installer to copy both the DLL and RSMods GUI to the game folder. If it's unable to automatically detect where Rocksmith is installed, it will ask you to point it to the correct folder.
-  
+
+### Running under Wine / Proton
+Install RSMods into the Rocksmith 2014 wineprefix using protontricks, then add this to the Rocksmith 2014 launch options in Steam:
+
+```
+WINEDLLOVERRIDES="xinput1_3=n,b" %command%
+```
+
 ## Requirements:
 * Latest Steam version of Rocksmith 2014 Remastered on Windows, https://store.steampowered.com/app/221680/Rocksmith_2014_Edition__Remastered/
 * MS Visual C++ 2015-2022 Redistributable for the DLL, .NET framework 4.7.2 for GUI/One-Click-Installer


### PR DESCRIPTION
Closes #179

Gets the mods working under Wine / Proton. Three things were blocking it:

1. Replaced syscall with `VirtualProtect` / `VirtualQuery` only in the wine path.

2. The D3D9 device was found by pattern-scanning Microsoft's `d3d9.dll`. DXVK
   and WineD3D never contain those bytes, and the existing Wine fallback
   dereferenced address `2`. Now creates a throwaway device and reads its vtable,
   and installs hooks by overwriting vtable entries instead of patching prologues
   whose lengths were specific to one build of `d3d9.dll`.

3. `Hook_EnumerationService` replayed the wrong instruction for one of the five
   bytes it overwrites, leaving ESP four bytes short and the function's SEH record
   installed at the wrong address. Harmless on Windows; fatal under Wine, which
   dispatches thousands of exceptions through that thread. This one is a bug fix on
   Windows too.

### Testing

Tested for an hour or two on Proton with DXVK and also verified it runs on WineD3D, everything works fine.
Still need to test native Windows.

There's a build in my fork for anyone that wants to test it themselves.